### PR TITLE
Installer RMariaDB fra github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN R -e "install.packages(c('digest',\
                              'pool',\
                              'readr',\
                              'rlang',\
-                             'remotes',\
+                             'RMariaDB',\
                              'rmarkdown', \
                              'shiny',\
                              'shinyjs',\
@@ -46,6 +46,6 @@ RUN R -e "install.packages(c('digest',\
                              'shinycssloaders',\
                              'tibble',\
                              'yaml'))" && \
-                             R -e "remotes::install_github('r-dbi/RMariaDB@*release')"
+                             R -e "install.packages('RMariaDB', repos='https://cloud.r-project.org/')"
 
 CMD ["R"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,13 +38,14 @@ RUN R -e "install.packages(c('digest',\
                              'pool',\
                              'readr',\
                              'rlang',\
-                             'RMariaDB',\
+                             'remotes',\
                              'rmarkdown', \
                              'shiny',\
                              'shinyjs',\
                              'shinyalert',\
                              'shinycssloaders',\
                              'tibble',\
-                             'yaml'))"
+                             'yaml'))" && \
+                             R -e "remotes::install_github('r-dbi/RMariaDB@*release')"
 
 CMD ["R"]


### PR DESCRIPTION
Problemer med å finne riktig systembibliotek hvis pakken bygges direkte fra cran. Mulig den må kompileres for å fungere i dette miljøet.

Closes #37