### PR TITLE
Alpine docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer "Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nor
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache --update-cache \
-        mariadb-connector-c-dev \
-        perl
+        mariadb-connector-c-dev
 
 ENV LC_ALL=nb_NO.UTF-8
 ENV LANG=nb_NO.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM rhub/r-minimal:4.2.3
 LABEL maintainer "Arnfinn Hykkerud Steindal <arnfinn.steindal@gmail.com>"
 
 # system libraries of general use
+# hadolint ignore=DL3018
 RUN apk add --no-cache --update-cache \
         --repository http://nl.alpinelinux.org/alpine/v3.11/main \
         autoconf=2.69-r2 \
@@ -32,6 +33,7 @@ RUN installr -d \
            tibble \
            yaml
 
+# hadolint ignore=DL3018
 RUN apk add --no-cache --update-cache \
         mariadb-dev mariadb-connector-c-dev perl cairo-dev \
         tzdata \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,38 @@
-FROM rocker/r-ver:4.3.1
+FROM rhub/r-minimal:4.2.3
 
-LABEL maintainer "Are Edvardsen <are.edvardsen@helse-nord.no>"
+LABEL maintainer "Arnfinn Hykkerud Steindal <arnfinn.steindal@gmail.com>"
 
 # system libraries of general use
-# hadolint ignore=DL3008
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    sudo \
-    pandoc \
-    libcurl3-gnutls \
-    libcurl4-gnutls-dev \
-    libcairo2-dev \
-    libxt-dev \
-    libxml2-dev \
-    libssl-dev \
-    libmysqlclient-dev \
-    texlive-latex-recommended \
-    texlive-latex-extra \
-    lmodern \
-    locales \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Set norsk bokmaal as default system locale
-RUN sed -i 's/^# *\(nb_NO.UTF-8\)/\1/' /etc/locale.gen \
-    && locale-gen \
-    && echo "LANG=\"nb_NO.UTF-8\"" > /etc/default/locale \
-    && update-locale LANG=nb_NO.utf8
+RUN apk add --no-cache --update-cache \
+        --repository http://nl.alpinelinux.org/alpine/v3.11/main \
+        autoconf=2.69-r2 \
+        automake=1.16.1-r0 \
+        mariadb
 
 ENV LC_ALL=nb_NO.UTF-8
 ENV LANG=nb_NO.UTF-8
 
-# install package dependencies
-RUN R -e "install.packages(c('digest',\
-                             'dplyr',\
-                             'DT',\
-                             'lifecycle',\
-                             'magrittr',\
-                             'pool',\
-                             'readr',\
-                             'rlang',\
-                             'RMariaDB',\
-                             'rmarkdown', \
-                             'shiny',\
-                             'shinyjs',\
-                             'shinyalert',\
-                             'shinycssloaders',\
-                             'tibble',\
-                             'yaml'))"
+RUN installr -d \
+        -t "libsodium-dev mariadb-dev curl-dev linux-headers autoconf automake" \
+        -a libsodium \
+           digest \
+           dplyr \
+           DT \
+           lifecycle \
+           magrittr \
+           pool \
+           readr \
+           rlang \
+           RMariaDB \
+           rmarkdown \
+           shiny \
+           shinyjs \
+           shinyalert \
+           shinycssloaders \
+           tibble \
+           yaml
+
+RUN apk add --no-cache --update-cache \
+        mariadb-dev mariadb-connector-c-dev perl cairo-dev
 
 CMD ["R"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,10 @@ RUN installr -d \
            shinyalert \
            shinycssloaders \
            tibble \
-           yaml
-
-RUN wget -q https://github.com/jgm/pandoc/releases/download/2.13/pandoc-2.13-linux-amd64.tar.gz \
-    && tar xzf pandoc-2.13-linux-amd64.tar.gz \
-    && mv pandoc-2.13/bin/* /usr/local/bin/ \
-    && rm -rf pandoc-2.13*
+           yaml \
+  && wget -q https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-linux-amd64.tar.gz \
+  && tar xzf pandoc-2.19.2-linux-amd64.tar.gz \
+  && mv pandoc-2.19.2/bin/* /usr/local/bin/ \
+  && rm -rf pandoc-2.19.2*
 
 CMD ["R"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,11 @@ RUN installr -d \
            yaml
 
 RUN apk add --no-cache --update-cache \
-        mariadb-dev mariadb-connector-c-dev perl cairo-dev
+        mariadb-dev mariadb-connector-c-dev perl cairo-dev \
+        tzdata \
+        && export TZDIR=/usr/share/zoneinfo
+
+ENV LC_ALL=nb_NO.UTF-8
+ENV LANG=nb_NO.UTF-8
 
 CMD ["R"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,10 @@ RUN apk add --no-cache --update-cache \
         tzdata \
         && export TZDIR=/usr/share/zoneinfo
 
+
+RUN wget https://github.com/jgm/pandoc/releases/download/2.13/pandoc-2.13-linux-amd64.tar.gz && \
+    tar xzf pandoc-2.13-linux-amd64.tar.gz && \
+    mv pandoc-2.13/bin/* /usr/local/bin/ && \
+    rm -rf pandoc-2.13*
+
 CMD ["R"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ LABEL maintainer "Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nor
 # hadolint ignore=DL3018
 RUN apk add --no-cache --update-cache \
         --repository http://nl.alpinelinux.org/alpine/v3.11/main \
-        autoconf=2.69-r2 \
-        automake=1.16.1-r0 \
         mariadb-connector-c-dev \
         perl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rhub/r-minimal:4.2.3
+FROM rhub/r-minimal:4.3.2
 
 LABEL maintainer "Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
 
@@ -7,7 +7,8 @@ RUN apk add --no-cache --update-cache \
         --repository http://nl.alpinelinux.org/alpine/v3.11/main \
         autoconf=2.69-r2 \
         automake=1.16.1-r0 \
-        mariadb
+        mariadb-connector-c-dev \
+        perl
 
 ENV LC_ALL=nb_NO.UTF-8
 ENV LANG=nb_NO.UTF-8
@@ -32,14 +33,9 @@ RUN installr -d \
            tibble \
            yaml
 
-# hadolint ignore=DL3018
-RUN apk add --no-cache --update-cache \
-        mariadb-dev mariadb-connector-c-dev perl cairo-dev \
-        tzdata \
-        && export TZDIR=/usr/share/zoneinfo \
-        && wget -q https://github.com/jgm/pandoc/releases/download/2.13/pandoc-2.13-linux-amd64.tar.gz \
-        && tar xzf pandoc-2.13-linux-amd64.tar.gz \
-        && mv pandoc-2.13/bin/* /usr/local/bin/ \
-        && rm -rf pandoc-2.13*
+RUN wget -q https://github.com/jgm/pandoc/releases/download/2.13/pandoc-2.13-linux-amd64.tar.gz \
+    && tar xzf pandoc-2.13-linux-amd64.tar.gz \
+    && mv pandoc-2.13/bin/* /usr/local/bin/ \
+    && rm -rf pandoc-2.13*
 
 CMD ["R"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN installr -d \
            digest \
            dplyr \
            DT \
-           lifecycle \
            magrittr \
            pool \
            readr \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ LABEL maintainer "Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nor
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache --update-cache \
-        --repository http://nl.alpinelinux.org/alpine/v3.11/main \
         mariadb-connector-c-dev \
         perl
 
@@ -12,8 +11,6 @@ ENV LC_ALL=nb_NO.UTF-8
 ENV LANG=nb_NO.UTF-8
 
 RUN installr -d \
-        -t "libsodium-dev mariadb-dev curl-dev linux-headers autoconf automake" \
-        -a libsodium \
            digest \
            dplyr \
            DT \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM rhub/r-minimal:4.2.3
 
-LABEL maintainer "Arnfinn Hykkerud Steindal <arnfinn.steindal@gmail.com>"
+LABEL maintainer "Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
 
-# system libraries of general use
 # hadolint ignore=DL3018
 RUN apk add --no-cache --update-cache \
         --repository http://nl.alpinelinux.org/alpine/v3.11/main \
@@ -38,8 +37,5 @@ RUN apk add --no-cache --update-cache \
         mariadb-dev mariadb-connector-c-dev perl cairo-dev \
         tzdata \
         && export TZDIR=/usr/share/zoneinfo
-
-ENV LC_ALL=nb_NO.UTF-8
-ENV LANG=nb_NO.UTF-8
 
 CMD ["R"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,12 +36,10 @@ RUN installr -d \
 RUN apk add --no-cache --update-cache \
         mariadb-dev mariadb-connector-c-dev perl cairo-dev \
         tzdata \
-        && export TZDIR=/usr/share/zoneinfo
-
-
-RUN wget https://github.com/jgm/pandoc/releases/download/2.13/pandoc-2.13-linux-amd64.tar.gz && \
-    tar xzf pandoc-2.13-linux-amd64.tar.gz && \
-    mv pandoc-2.13/bin/* /usr/local/bin/ && \
-    rm -rf pandoc-2.13*
+        && export TZDIR=/usr/share/zoneinfo \
+        && wget -q https://github.com/jgm/pandoc/releases/download/2.13/pandoc-2.13-linux-amd64.tar.gz \
+        && tar xzf pandoc-2.13-linux-amd64.tar.gz \
+        && mv pandoc-2.13/bin/* /usr/local/bin/ \
+        && rm -rf pandoc-2.13*
 
 CMD ["R"]


### PR DESCRIPTION
Bruke [Alpine Linux-image](https://github.com/r-hub/r-minimal) i stedet for [Ubuntu-image](https://rocker-project.org/images/versioned/r-ver.html).

Dropper LaTeX, som ikke lenger trengs etter https://github.com/mong/imongr/pull/385 (terms kan lastes ned som html nå). Installerer Pandoc fra scratch (finnes ikke pakke til Alpine).

Endringene er testet lokalt sammen med siste versjon av `imongr`.

Image går fra 1,62 GB til 300 MB.