### PR TITLE
rhub/r-minimal:4.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rhub/r-minimal:4.6.0
+FROM rhub/r-minimal:4.6.1
 
 LABEL maintainer="Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
 


### PR DESCRIPTION
Oppdatert fra rhub/r-minimal:4.6.0, som hadde fått noen sikkerhetshull.