### PR TITLE
Revert "Bygg amd64 og arm64 i to ulike bygg (#107)"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   push_to_registries:
     name: Push Docker image to docker hub

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,17 +9,10 @@ on:
     branches:
       - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   push_to_registries:
     name: Push Docker image to docker hub
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: [linux/amd64, linux/arm64]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7
@@ -51,7 +44,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}


### PR DESCRIPTION
This (partly) reverts commit 71b6c8c31829bcb894facf20e8cc4161ea138255.

De ulike platformene må dyttes opp samtidig. Ellers beholdes kun den siste som ble dyttet opp til dockerhub (som regel arm64).